### PR TITLE
Implement species registration, update, and read-only queries with admin authorization in STX-VerdaVault contract

### DIFF
--- a/contracts/STX-VerdaVault.clar
+++ b/contracts/STX-VerdaVault.clar
@@ -150,3 +150,139 @@
         )
     )
 )
+
+;; Species management functions
+(define-public (register-species 
+                (common-species-name (string-ascii 50))
+                (scientific-species-name (string-ascii 100))
+                (initial-population-count uint)
+                (parent-ecosystem-id uint)
+                (conservation-status (string-ascii 20)))
+    (begin
+        (asserts! (is-contract-administrator) ERR_ADMIN_ONLY)
+        (asserts! (> (len common-species-name) u0) ERR_INVALID_INPUT)
+        (asserts! (> initial-population-count u0) ERR_ZERO_VALUE)
+        (asserts! (is-ecosystem-registered parent-ecosystem-id) ERR_INVALID_ECOSYSTEM_ID)
+        (asserts! (or (is-eq conservation-status "threatened")
+                     (is-eq conservation-status "stable")
+                     (is-eq conservation-status "endangered")
+                     (is-eq conservation-status "extinct")) ERR_INVALID_CONSERVATION_STATUS)
+
+        (let
+            (
+                (new-species-id (var-get next-species-id))
+                (current-ecosystem-biodiversity (unwrap! (map-get? ecosystem-biodiversity-summary { ecosystem-id: parent-ecosystem-id }) ERR_DATA_NOT_FOUND))
+                (validated-scientific-name (unwrap! (validate-string-input scientific-species-name) ERR_INVALID_INPUT))
+            )
+            ;; Check the validation result before using
+            (asserts! (is-some (some validated-scientific-name)) ERR_INVALID_INPUT)
+
+            (map-insert species-registry
+                { species-id: new-species-id }
+                {
+                    common-species-name: common-species-name,
+                    scientific-species-name: validated-scientific-name,
+                    current-population-count: initial-population-count,
+                    parent-ecosystem-id: parent-ecosystem-id,
+                    conservation-status: conservation-status,
+                    last-population-census-block: stacks-block-height
+                }
+            )
+
+            (map-set ecosystem-biodiversity-summary
+                { ecosystem-id: parent-ecosystem-id }
+                {
+                    total-recorded-species: (+ (get total-recorded-species current-ecosystem-biodiversity) u1),
+                    biodiversity-complexity-index: (+ (get biodiversity-complexity-index current-ecosystem-biodiversity) u1),
+                    threatened-species-count: (if (is-eq conservation-status "threatened")
+                                             (+ (get threatened-species-count current-ecosystem-biodiversity) u1)
+                                             (get threatened-species-count current-ecosystem-biodiversity)),
+                    last-biodiversity-assessment-block: stacks-block-height
+                }
+            )
+
+            (var-set next-species-id (+ new-species-id u1))
+            (var-set total-registered-species (+ (var-get total-registered-species) u1))
+            (ok new-species-id)
+        )
+    )
+)
+
+(define-public (update-species-population 
+                (species-id uint)
+                (updated-population-count uint)
+                (updated-conservation-status (string-ascii 20)))
+    (let
+        (
+            (current-species-details (unwrap! (map-get? species-registry { species-id: species-id }) ERR_DATA_NOT_FOUND))
+            (current-ecosystem-biodiversity (unwrap! (map-get? ecosystem-biodiversity-summary 
+                { ecosystem-id: (get parent-ecosystem-id current-species-details) }) ERR_DATA_NOT_FOUND))
+        )
+        (asserts! (is-contract-administrator) ERR_ADMIN_ONLY)
+        (asserts! (>= updated-population-count u0) ERR_INVALID_INPUT)
+        (asserts! (or (is-eq updated-conservation-status "threatened")
+                     (is-eq updated-conservation-status "stable")
+                     (is-eq updated-conservation-status "endangered")
+                     (is-eq updated-conservation-status "extinct")) ERR_INVALID_CONSERVATION_STATUS)
+        (asserts! (is-species-registered species-id) ERR_INVALID_SPECIES_ID)
+
+        (map-set species-registry
+            { species-id: species-id }
+            {
+                common-species-name: (get common-species-name current-species-details),
+                scientific-species-name: (get scientific-species-name current-species-details),
+                current-population-count: updated-population-count,
+                parent-ecosystem-id: (get parent-ecosystem-id current-species-details),
+                conservation-status: updated-conservation-status,
+                last-population-census-block: stacks-block-height
+            }
+        )
+
+        ;; Update threatened species count if status changed
+        (if (not (is-eq (get conservation-status current-species-details) updated-conservation-status))
+            (map-set ecosystem-biodiversity-summary
+                { ecosystem-id: (get parent-ecosystem-id current-species-details) }
+                {
+                    total-recorded-species: (get total-recorded-species current-ecosystem-biodiversity),
+                    biodiversity-complexity-index: (get biodiversity-complexity-index current-ecosystem-biodiversity),
+                    threatened-species-count: (if (is-eq updated-conservation-status "threatened")
+                                             (+ (get threatened-species-count current-ecosystem-biodiversity) u1)
+                                             (- (get threatened-species-count current-ecosystem-biodiversity) u1)),
+                    last-biodiversity-assessment-block: stacks-block-height
+                }
+            )
+            true
+        )
+        (ok true)
+    )
+)
+
+;; Read-only functions
+(define-read-only (get-ecosystem-details (ecosystem-id uint))
+    (map-get? ecosystem-registry { ecosystem-id: ecosystem-id })
+)
+
+(define-read-only (get-species-details (species-id uint))
+    (map-get? species-registry { species-id: species-id })
+)
+
+(define-read-only (get-ecosystem-biodiversity-summary (ecosystem-id uint))
+    (map-get? ecosystem-biodiversity-summary { ecosystem-id: ecosystem-id })
+)
+
+(define-read-only (get-total-ecosystems)
+    (ok (var-get total-registered-ecosystems))
+)
+
+(define-read-only (get-total-species)
+    (ok (var-get total-registered-species))
+)
+
+;; Helper functions
+(define-read-only (is-ecosystem-registered (ecosystem-id uint))
+    (is-some (map-get? ecosystem-registry { ecosystem-id: ecosystem-id }))
+)
+
+(define-read-only (is-species-registered (species-id uint))
+    (is-some (map-get? species-registry { species-id: species-id }))
+)


### PR DESCRIPTION

### Pull Request Description

**Title:** Add Species Registration, Population Update, and Read-Only Query Functions to STX-VerdaVault Contract

**Description:**

This pull request extends the `STX-VerdaVault` smart contract by adding comprehensive species management capabilities to complement the existing ecosystem management features. It enables the registration and updating of species data within ecosystems, maintaining biodiversity metrics on-chain with strict administrative controls.

**New Features:**

* **Species Registration (`register-species`):**
  Allows the contract administrator to register new species under a specific ecosystem. The function validates inputs including species names, initial population count, parent ecosystem existence, and conservation status (restricted to “threatened,” “stable,” “endangered,” or “extinct”). It updates ecosystem biodiversity summaries accordingly by incrementing species counts and biodiversity indices, and adjusting threatened species counts if applicable.

* **Species Population and Status Update (`update-species-population`):**
  Permits the contract administrator to update the population count and conservation status of a registered species. This function ensures input validity, checks species existence, and updates ecosystem biodiversity summaries dynamically to reflect changes in threatened species status, preserving accurate ecological data.

* **Read-Only Query Functions:**

  * Retrieve details of an ecosystem or species by ID.
  * Fetch biodiversity summaries for ecosystems.
  * Obtain total counts of registered ecosystems and species.
  * Check if a species or ecosystem is registered.
